### PR TITLE
chore/build: use imap-next 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,19 +5,23 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-imap-flow = { git = "https://github.com/duesee/imap-flow", features = ["expose_stream"] }
-imap-types = "2"
 once_cell = "1"
 rustls-native-certs = "0.7.0"
-tag-generator = { git = "https://github.com/duesee/imap-flow" }
 thiserror = "1.0.50"
 tokio = { version = "1.37.0", features = ["net", "time"] }
 tokio-rustls = "0.26.0"
 tracing = "0.1.40"
 
-[dev-dependencies]
-tokio = { version = "1.37.0", features = ["full"] }
+[dependencies.imap-next]
+version = "0.2.0"
+features = [
+    "expose_stream",
+    "tag_generator",
+    "starttls",
+    "ext_id",
+    "ext_metadata",
+]
 
-[patch.crates-io]
-imap-codec = { git = "https://github.com/duesee/imap-codec" }
-imap-types = { git = "https://github.com/duesee/imap-codec" }
+[dev-dependencies]
+static_assertions = "1.1.0"
+tokio = { version = "1.37.0", features = ["full"] }

--- a/src/tasks/tasks/append.rs
+++ b/src/tasks/tasks/append.rs
@@ -1,4 +1,4 @@
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     datetime::DateTime,
     extensions::binary::LiteralOrLiteral8,

--- a/src/tasks/tasks/appenduid.rs
+++ b/src/tasks/tasks/appenduid.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     datetime::DateTime,
     extensions::binary::LiteralOrLiteral8,

--- a/src/tasks/tasks/authenticate.rs
+++ b/src/tasks/tasks/authenticate.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use imap_types::{
+use imap_next::imap_types::{
     auth::{AuthMechanism, AuthenticateData},
     command::CommandBody,
     core::Vec1,

--- a/src/tasks/tasks/capability.rs
+++ b/src/tasks/tasks/capability.rs
@@ -1,4 +1,4 @@
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     core::Vec1,
     response::{Capability, Code, Data, StatusBody, StatusKind},

--- a/src/tasks/tasks/check.rs
+++ b/src/tasks/tasks/check.rs
@@ -1,4 +1,4 @@
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     response::{StatusBody, StatusKind},
 };

--- a/src/tasks/tasks/copy.rs
+++ b/src/tasks/tasks/copy.rs
@@ -1,4 +1,4 @@
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     mailbox::Mailbox,
     response::{StatusBody, StatusKind},

--- a/src/tasks/tasks/create.rs
+++ b/src/tasks/tasks/create.rs
@@ -1,4 +1,4 @@
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     mailbox::Mailbox,
     response::{StatusBody, StatusKind},

--- a/src/tasks/tasks/delete.rs
+++ b/src/tasks/tasks/delete.rs
@@ -1,4 +1,4 @@
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     mailbox::Mailbox,
     response::{StatusBody, StatusKind},

--- a/src/tasks/tasks/expunge.rs
+++ b/src/tasks/tasks/expunge.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     response::{Data, StatusBody, StatusKind},
 };

--- a/src/tasks/tasks/fetch.rs
+++ b/src/tasks/tasks/fetch.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, num::NonZeroU32};
 
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     core::Vec1,
     fetch::{MacroOrMessageDataItemNames, MessageDataItem},

--- a/src/tasks/tasks/id.rs
+++ b/src/tasks/tasks/id.rs
@@ -1,4 +1,4 @@
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     core::{IString, NString},
     response::{Data, StatusBody, StatusKind},

--- a/src/tasks/tasks/list.rs
+++ b/src/tasks/tasks/list.rs
@@ -1,4 +1,4 @@
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     core::QuotedChar,
     flag::FlagNameAttribute,

--- a/src/tasks/tasks/logout.rs
+++ b/src/tasks/tasks/logout.rs
@@ -1,4 +1,4 @@
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     response::{Bye, StatusBody, StatusKind},
 };

--- a/src/tasks/tasks/mod.rs
+++ b/src/tasks/tasks/mod.rs
@@ -1,4 +1,4 @@
-use imap_types::response::StatusBody;
+use imap_next::imap_types::response::StatusBody;
 use thiserror::Error;
 
 pub mod append;

--- a/src/tasks/tasks/move.rs
+++ b/src/tasks/tasks/move.rs
@@ -1,4 +1,4 @@
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     mailbox::Mailbox,
     response::{StatusBody, StatusKind},

--- a/src/tasks/tasks/noop.rs
+++ b/src/tasks/tasks/noop.rs
@@ -1,4 +1,4 @@
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     response::{StatusBody, StatusKind},
 };

--- a/src/tasks/tasks/search.rs
+++ b/src/tasks/tasks/search.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     core::Vec1,
     response::{Data, StatusBody, StatusKind},

--- a/src/tasks/tasks/select.rs
+++ b/src/tasks/tasks/select.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     flag::{Flag, FlagPerm},
     mailbox::Mailbox,

--- a/src/tasks/tasks/sort.rs
+++ b/src/tasks/tasks/sort.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     core::{Charset, Vec1},
     extensions::sort::SortCriterion,

--- a/src/tasks/tasks/starttls.rs
+++ b/src/tasks/tasks/starttls.rs
@@ -1,4 +1,4 @@
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     response::{StatusBody, StatusKind},
 };

--- a/src/tasks/tasks/store.rs
+++ b/src/tasks/tasks/store.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, num::NonZeroU32};
 
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     core::Vec1,
     fetch::MessageDataItem,

--- a/src/tasks/tasks/thread.rs
+++ b/src/tasks/tasks/thread.rs
@@ -1,4 +1,4 @@
-use imap_types::{
+use imap_next::imap_types::{
     command::CommandBody,
     core::{Charset, Vec1},
     extensions::thread::{Thread, ThreadingAlgorithm},


### PR DESCRIPTION
This updates `imap-client` to use `imap-next` 0.2.0 (from crates.io). Can you somehow verify if this suits your needs? Happy to talk about it :-)